### PR TITLE
Set height for Firefox drag-and-drop

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -290,6 +290,7 @@ function handleHtml(db: Database, url: URL): string | { redirectHref: string } |
             margin: 0;
             padding: 0;
             font-size: smaller;
+            height: 100%;
         }
 
         a, a:visited {


### PR DESCRIPTION
In Firefox the `body` element was only taking up the content size, not the full height of the page. Dragging in the JSON file would open the file instead of uploading it if you didn't drag over the existing elements. 